### PR TITLE
Implement CSV export, dark mode toggle and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ wp_page_analyzer/
     python app.py
     ```
 
-5.  Apri il browser su `http://12.0.0.1:5000/`
+5.  Apri il browser su `http://127.0.0.1:5000/`
 
 ---
 
@@ -98,6 +98,16 @@ Se desideri contribuire al progetto:
     ```
 
 4.  Esegui il push sul tuo fork e apri una Pull Request al repository originale.
+
+---
+
+## 🧪 Test
+
+Per eseguire i test automatici basta lanciare:
+
+```bash
+pytest
+```
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask
-requests
-Flask-Cors
-beautifulsoup4
+Flask>=2.3
+requests>=2.31
+Flask-Cors>=4.0
+beautifulsoup4>=4.12

--- a/static/js/handlers.js
+++ b/static/js/handlers.js
@@ -43,6 +43,27 @@ export function bindUI() {
   document.getElementById('exportMd')?.addEventListener('click', () => { exportMD(); });
   document.getElementById('saveReport')?.addEventListener('click', () => { saveReport(); });
   document.getElementById('uploadReport')?.addEventListener('change', evt => { handleUpload(evt); });
+
+  const darkToggle = document.getElementById('darkToggle');
+  const body = document.body;
+  if (darkToggle) {
+    if (localStorage.getItem('darkMode') === 'true') {
+      body.classList.add('bg-dark');
+      body.classList.remove('bg-light');
+      darkToggle.textContent = 'Light Mode';
+    }
+    darkToggle.addEventListener('click', () => {
+      const isDark = body.classList.toggle('bg-dark');
+      body.classList.toggle('bg-light', !isDark);
+      if (isDark) {
+        localStorage.setItem('darkMode', 'true');
+        darkToggle.textContent = 'Light Mode';
+      } else {
+        localStorage.removeItem('darkMode');
+        darkToggle.textContent = 'Dark Mode';
+      }
+    });
+  }
 }
 
 /**

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,34 @@
+import json
+from unittest.mock import patch, Mock
+from wp_analyzer import create_app
+
+app = create_app()
+
+
+def test_download_csv():
+    client = app.test_client()
+    groups = [
+        {'category': 'Pages', 'items': [
+            {'id': 1, 'title': 'Home', 'link': 'http://example.com', 'status': 'publish'}
+        ]}
+    ]
+    resp = client.post('/download_csv', json={'groups': groups})
+    assert resp.status_code == 200
+    assert resp.mimetype == 'text/csv'
+    data = resp.get_data(as_text=True)
+    assert 'category,id,title,link,status' in data
+    assert 'Pages,1,Home,http://example.com,publish' in data
+
+
+def test_performance_endpoint():
+    client = app.test_client()
+    mock_resp = Mock()
+    mock_resp.status_code = 200
+    mock_resp.elapsed.total_seconds.return_value = 0.1
+    mock_resp.headers = {'Content-Length': '123'}
+    with patch('requests.get', return_value=mock_resp):
+        resp = client.post('/analyze/performance', json={'url': 'https://example.com'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['status_code'] == 200
+    assert data['content_length'] == 123

--- a/wp_analyzer/__init__.py
+++ b/wp_analyzer/__init__.py
@@ -24,6 +24,7 @@ def create_app():
     from .users           import bp as users_bp;          app.register_blueprint(users_bp,          url_prefix='/analyze/users')
     from .broken          import bp as broken_bp;         app.register_blueprint(broken_bp,         url_prefix='/analyze/broken')
     from .reports         import bp as reports_bp;        app.register_blueprint(reports_bp,        url_prefix='/reports')
+    from .export_csv      import bp as export_csv_bp;     app.register_blueprint(export_csv_bp)
 
     @app.route('/')
     def index():

--- a/wp_analyzer/export_csv.py
+++ b/wp_analyzer/export_csv.py
@@ -1,0 +1,29 @@
+import csv
+from io import StringIO
+from flask import Blueprint, request, make_response
+
+bp = Blueprint('export_csv', __name__)
+
+@bp.route('/download_csv', methods=['POST'])
+def download_csv():
+    data = request.json or {}
+    groups = data.get('groups', [])
+
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(['category', 'id', 'title', 'link', 'status'])
+    for group in groups:
+        category = group.get('category', '')
+        for item in group.get('items', []):
+            writer.writerow([
+                category,
+                item.get('id', ''),
+                item.get('title', ''),
+                item.get('link', ''),
+                item.get('status', '')
+            ])
+
+    resp = make_response(output.getvalue())
+    resp.headers['Content-Disposition'] = 'attachment; filename=content.csv'
+    resp.mimetype = 'text/csv'
+    return resp


### PR DESCRIPTION
## Summary
- add Flask blueprint to download CSV
- fix local server URL in README and mention pytest
- pin dependency versions
- implement dark mode toggle in JS
- create basic tests for CSV and performance endpoints

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*